### PR TITLE
fixed url for arria2 for quartus lite 18.1

### DIFF
--- a/quartus-install.py
+++ b/quartus-install.py
@@ -97,6 +97,7 @@ quartus_url_181std = {
 
 quartus_url_181lite = dict(quartus_url_181std)
 quartus_url_181lite['setup'] = "http://download.altera.com/akdlm/software/acdsinst/18.1std/625/ib_installers/QuartusLiteSetup-18.1.0.625-linux.run"
+quartus_url_181lite['a2'] = "http://download.altera.com/akdlm/software/acdsinst/18.1std/625/ib_installers/arria_lite-18.1.0.625.qdz"
 
 
 quartus_url_171std = {


### PR DESCRIPTION
The url to download the component arria 2 is different for quartus lite