### PR TITLE
chmod: set exec perms on all downloaded .run files

### DIFF
--- a/quartus-install.py
+++ b/quartus-install.py
@@ -317,7 +317,7 @@ import subprocess
 import sys
 import argparse
 import tempfile
-
+import stat
 
 def match_wanted_parts(version, devices):
     # work out what devices we have available
@@ -371,7 +371,6 @@ def install_quartus(version, installdir):
     
 def run_installer(installerfile, installdir):
     leafname = os.path.basename(installerfile)
-    os.chmod(leafname, 0o755)
     target = os.path.abspath(installdir)
     args = ['--mode', 'unattended', '--unattendedmodeui', 'minimal']
     numeric_version = ''.join(i for i in version if i.isdigit() or i=='.')
@@ -424,6 +423,11 @@ parts = parts + match_wanted_parts(version, args.device)
 if not args.install_only:
     print("Downloading Quartus %s parts %s\n" % (version, parts))
     rc, urls = download_quartus(version, parts, args)
+    for url in urls:
+        leafname = url[url.rfind("/")+1:]
+        if os.path.exists(leafname) and leafname.endswith(".run"):
+            os.chmod(leafname, stat.S_IRWXU | stat.S_IXGRP | stat.S_IRGRP | stat.S_IXOTH | stat.S_IROTH)
+
 if not args.download_only:
     print("Installing Quartus\n")
     install_quartus(version, target)


### PR DESCRIPTION
First of all: your installer was a huge discovery for me. It's small, just works, just self explaining, just awesome!! Just one minor issue I had (might be that I'm using it wrong): when installing quartus 18.1 together with AOCL, the AOCL setup .run script did not have exec permissions, thus failed to install automatically. I learned the quartus installer seems to call the AOCLSetup implicitely and where you're python script is doing a chmod 755 at explicit calls of .run files - if my understanding is correct - this will miss cases where this happens implicitely. So, my pull request proposal here instead will set exec permissions already after the download step in case of a .run file. For me the installation runs smoothly. Perhaps you could verify. Feel free to drop or accept it if you think this is usefull, I would appreciate. Thanks.