### PR TITLE
Support Quartus web versions 15.0 - 13.0 SP1

### DIFF
--- a/quartus-install.py
+++ b/quartus-install.py
@@ -315,7 +315,18 @@ quartus_url_151std = {
 	's5' : 'https://download.altera.com/akdlm/software/acdsinst/15.1/185/ib_installers/stratixv-15.1.0.185.qdz'
 }
 
+quartus_url_150web = {
+        'setup' : 'https://download.altera.com/akdlm/software/acdsinst/15.0/145/ib_installers/QuartusSetupWeb-15.0.0.145-linux.run',
+        'modelsim' : 'https://download.altera.com/akdlm/software/acdsinst/15.0/145/ib_installers/ModelSimSetup-15.0.0.145-linux.run',
+        'a2' : 'https://download.altera.com/akdlm/software/acdsinst/15.0/145/ib_installers/arria-15.0.0.145.qdz',
+        'c4' : 'https://download.altera.com/akdlm/software/acdsinst/15.0/145/ib_installers/cyclone-15.0.0.145.qdz',
+        'c5' : 'https://download.altera.com/akdlm/software/acdsinst/15.0/145/ib_installers/cyclonev-15.0.0.145.qdz',
+        'm2' : 'https://download.altera.com/akdlm/software/acdsinst/15.0/145/ib_installers/max-15.0.0.145.qdz',
+        'm10' : 'https://download.altera.com/akdlm/software/acdsinst/15.0/145/ib_installers/max10-15.0.0.145.qdz'
+}
+
 quartus_versions = {
+    '15.0web' : quartus_url_150web,
     '15.1std' : quartus_url_151std,
     '16.0std' : quartus_url_160std,
     '16.1std' : quartus_url_161std,

--- a/quartus-install.py
+++ b/quartus-install.py
@@ -335,7 +335,18 @@ quartus_url_141web = {
         'm10' : 'https://download.altera.com/akdlm/software/acdsinst/14.1/186/ib_installers/max10-14.1.0.186.qdz'
 }
 
+quartus_url_140web = {
+        'setup' : 'https://download.altera.com/akdlm/software/acdsinst/14.0/200/ib_installers/QuartusSetupWeb-14.0.0.200-linux.run',
+        'modelsim' : 'https://download.altera.com/akdlm/software/acdsinst/14.0/200/ib_installers/ModelSimSetup-14.0.0.200-linux.run',
+        'a2' : 'https://download.altera.com/akdlm/software/acdsinst/14.0/200/ib_installers/arria-14.0.0.200.qdz',
+        'c4' : 'https://download.altera.com/akdlm/software/acdsinst/14.0/200/ib_installers/cyclone-14.0.0.200.qdz',
+        'c5' : 'https://download.altera.com/akdlm/software/acdsinst/14.0/200/ib_installers/cyclonev-14.0.0.200.qdz',
+        'm2' : 'https://download.altera.com/akdlm/software/acdsinst/14.0/200/ib_installers/max-14.0.0.200.qdz',
+}
+
+
 quartus_versions = {
+    '14.0web' : quartus_url_140web,
     '14.1web' : quartus_url_141web,
     '15.0web' : quartus_url_150web,
     '15.1std' : quartus_url_151std,

--- a/quartus-install.py
+++ b/quartus-install.py
@@ -325,7 +325,18 @@ quartus_url_150web = {
         'm10' : 'https://download.altera.com/akdlm/software/acdsinst/15.0/145/ib_installers/max10-15.0.0.145.qdz'
 }
 
+quartus_url_141web = {
+        'setup' : 'https://download.altera.com/akdlm/software/acdsinst/14.1/186/ib_installers/QuartusSetupWeb-14.1.0.186-linux.run',
+        'modelsim' : 'https://download.altera.com/akdlm/software/acdsinst/14.1/186/ib_installers/ModelSimSetup-14.1.0.186-linux.run',
+        'a2' : 'https://download.altera.com/akdlm/software/acdsinst/14.1/186/ib_installers/arria-14.1.0.186.qdz',
+        'c4' : 'https://download.altera.com/akdlm/software/acdsinst/14.1/186/ib_installers/cyclone-14.1.0.186.qdz',
+        'c5' : 'https://download.altera.com/akdlm/software/acdsinst/14.1/186/ib_installers/cyclonev-14.1.0.186.qdz',
+        'm2' : 'https://download.altera.com/akdlm/software/acdsinst/14.1/186/ib_installers/max-14.1.0.186.qdz',
+        'm10' : 'https://download.altera.com/akdlm/software/acdsinst/14.1/186/ib_installers/max10-14.1.0.186.qdz'
+}
+
 quartus_versions = {
+    '14.1web' : quartus_url_141web,
     '15.0web' : quartus_url_150web,
     '15.1std' : quartus_url_151std,
     '16.0std' : quartus_url_160std,

--- a/quartus-install.py
+++ b/quartus-install.py
@@ -353,8 +353,18 @@ quartus_url_131web = {
         'm2' : 'https://download.altera.com/akdlm/software/acdsinst/13.1/162/ib_installers/max-13.1.0.162.qdz',
 }
 
+quartus_url_130sp1web = {
+        'setup' : 'https://download.altera.com/akdlm/software/acdsinst/13.0sp1/232/ib_installers/QuartusSetupWeb-13.0.1.232.run',
+        'modelsim' : 'https://download.altera.com/akdlm/software/acdsinst/13.0sp1/232/ib_installers/ModelSimSetup-13.0.1.232.run',
+        'a2' : 'https://download.altera.com/akdlm/software/acdsinst/13.0sp1/232/ib_installers/arria-13.0.1.232.qdz',
+        'c4' : 'https://download.altera.com/akdlm/software/acdsinst/13.0sp1/232/ib_installers/cyclone-13.0.1.232.qdz',
+        'c5' : 'https://download.altera.com/akdlm/software/acdsinst/13.0sp1/232/ib_installers/cyclonev-13.0.1.232.qdz',
+        'm2' : 'https://download.altera.com/akdlm/software/acdsinst/13.0sp1/232/ib_installers/max-13.0.1.232.qdz',
+}
+
 
 quartus_versions = {
+    '13.0sp1web' : quartus_url_130sp1web,
     '13.1web' : quartus_url_131web,
     '14.0web' : quartus_url_140web,
     '14.1web' : quartus_url_141web,

--- a/quartus-install.py
+++ b/quartus-install.py
@@ -344,8 +344,18 @@ quartus_url_140web = {
         'm2' : 'https://download.altera.com/akdlm/software/acdsinst/14.0/200/ib_installers/max-14.0.0.200.qdz',
 }
 
+quartus_url_131web = {
+        'setup' : 'https://download.altera.com/akdlm/software/acdsinst/13.1/162/ib_installers/QuartusSetupWeb-13.1.0.162.run',
+        'modelsim' : 'https://download.altera.com/akdlm/software/acdsinst/13.1/162/ib_installers/ModelSimSetup-13.1.0.162.run',
+        'a2' : 'https://download.altera.com/akdlm/software/acdsinst/13.1/162/ib_installers/arria-13.1.0.162.qdz',
+        'c4' : 'https://download.altera.com/akdlm/software/acdsinst/13.1/162/ib_installers/cyclone-13.1.0.162.qdz',
+        'c5' : 'https://download.altera.com/akdlm/software/acdsinst/13.1/162/ib_installers/cyclonev-13.1.0.162.qdz',
+        'm2' : 'https://download.altera.com/akdlm/software/acdsinst/13.1/162/ib_installers/max-13.1.0.162.qdz',
+}
+
 
 quartus_versions = {
+    '13.1web' : quartus_url_131web,
     '14.0web' : quartus_url_140web,
     '14.1web' : quartus_url_141web,
     '15.0web' : quartus_url_150web,


### PR DESCRIPTION
These have been test downloaded and installed.
Versions below are removed from Intel/Altera download site